### PR TITLE
Take env variables from environment when missing .env file

### DIFF
--- a/api/qupo_backend/config.py
+++ b/api/qupo_backend/config.py
@@ -2,19 +2,8 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
-    azure_tenant_id: str
-    azure_client_id: str
-    azure_client_secret: str
-    azure_resource_group: str
-    azure_location: str
-    azure_name: str
-    azure_subscription_id: str
-    ibmq_client_secret: str
     use_db: bool = True
     sqllite_db_url: str = 'sqlite:///./qupo_backend/db/finance.db'
-
-    class Config:
-        env_file = '.env'
 
 
 settings = Settings()

--- a/api/qupo_backend/models/optimization_backend/backend_runner.py
+++ b/api/qupo_backend/models/optimization_backend/backend_runner.py
@@ -1,6 +1,8 @@
 # native packages
 from dataclasses import dataclass
+from dotenv import load_dotenv
 from enum import Enum
+import os
 import warnings
 
 # 3rd party packages
@@ -21,9 +23,10 @@ from qiskit.providers.ibmq import IBMQAccountError
 from qiskit_optimization.algorithms import MinimumEigenOptimizer
 
 # custom packages
-from qupo_backend.config import settings
 from .optimization_classes import Result
 from .model_converter import convert_qubo_to_azureqio_model
+
+load_dotenv()
 
 
 def run_job(job):
@@ -62,20 +65,20 @@ def run_osqp_job(job):
 
 
 def configure_azure_provider(quantum=False):
-    credential = ClientSecretCredential(tenant_id=settings.azure_tenant_id,
-                                        client_id=settings.azure_client_id,
-                                        client_secret=settings.azure_client_secret)
+    credential = ClientSecretCredential(tenant_id=os.getenv('AZURE_TENANT_ID'),
+                                        client_id=os.getenv('AZURE_CLIENT_ID'),
+                                        client_secret=os.getenv('AZURE_CLIENT_SECRET'))
     if quantum:
-        azure_provider = AzureQuantumProvider(subscription_id=settings.azure_subscription_id,
-                                              resource_group=settings.azure_resource_group,
-                                              name=settings.azure_name,
-                                              location=settings.azure_location,
+        azure_provider = AzureQuantumProvider(subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
+                                              resource_group=os.getenv('AZURE_RESOURCE_GROUP'),
+                                              name=os.getenv('AZURE_NAME'),
+                                              location=os.getenv('AZURE_LOCATION'),
                                               credential=credential)
     else:
-        azure_provider = Workspace(subscription_id=settings.azure_subscription_id,
-                                   resource_group=settings.azure_resource_group,
-                                   name=settings.azure_name,
-                                   location=settings.azure_location,
+        azure_provider = Workspace(subscription_id=os.getenv('AZURE_SUBSCRIPTION_ID'),
+                                   resource_group=os.getenv('AZURE_RESOURCE_GROUP'),
+                                   name=os.getenv('AZURE_NAME'),
+                                   location=os.getenv('AZURE_LOCATION'),
                                    credential=credential)
     return azure_provider
 
@@ -119,7 +122,7 @@ def run_qio_job(job):
 
 def configure_qiskit_provider():
     try:
-        IBMQ.enable_account(settings.ibmq_client_secret)
+        IBMQ.enable_account(os.getenv('IBMQ_CLIENT_SECRET'))
     except IBMQAccountError:
         warnings.warn('IBM account not available. Please check ibmq health status and credentials')
         pass

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,7 @@
 azure-quantum[qiskit]==0.25.222597
 click==8.1.3
 dimod==0.11.5
+dotenv==0.20.0
 fastapi==0.75.1
 flake8==4.0.1
 flake8-quotes==3.3.1

--- a/api/test/stockdata_integrator_runscript.py
+++ b/api/test/stockdata_integrator_runscript.py
@@ -1,17 +1,20 @@
 import sys
 import os.path
+import os
 import warnings
 import json
 import yfinance
 import quandl
 import numpy as np
+from dotenv import load_dotenv
 from dataclasses import dataclass, InitVar
 from qupo_backend.models.finance_classes import Stock, PortfolioModel
 import qupo_backend.models.finance_utilities as finance_utilities
 from qupo_backend.tickers_utilities import stock_data_to_dataframe
-from qupo_backend.config import settings
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+
+load_dotenv()
 
 
 @dataclass
@@ -43,7 +46,7 @@ class Portfolio:
 
 
 def extract_quandl_data(api_key=None, identifier='UPR/EXT'):
-    quandl.ApiConfig.api_key = settings.nasdaq_api_key
+    quandl.ApiConfig.api_key = os.getenv('NASDAQ_API_KEY')
     return quandl.get_table(identifier, qopts={'columns': ['company_name', 'net_impact_ratio']})
 
 


### PR DESCRIPTION
Environment variables are empty in deployment because the settings of the backend take them form a `.env` which doesn't exist in deployment. Restructure the backend to use env variables from the .env file if present, otherwise take them out from the environment.

Closes #65 